### PR TITLE
Update TF-Via-PR-Comments link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A list of OpenTofu resources.
 ### CI
 
 - [setup-opentofu](https://github.com/opentofu/setup-opentofu) - Set up OpenTofu CLI in your GitHub Actions workflow.
-- [tf-via-pr](https://github.com/devsectop/tf-via-pr) - Run Terraform or OpenTofu commands via GitHub PR comments.
+- [tf-via-pr-comments](https://github.com/devsectop/tf-via-pr-comments) - Run Terraform or OpenTofu commands via GitHub PR comments.
 - [terraform-github-actions](https://github.com/dflook/terraform-github-actions) - GitHub Actions for OpenTofu.
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A list of OpenTofu resources.
 ### CI
 
 - [setup-opentofu](https://github.com/opentofu/setup-opentofu) - Set up OpenTofu CLI in your GitHub Actions workflow.
-- [tf-via-pr-comments](https://github.com/devsectop/tf-via-pr-comments) - Run Terraform or OpenTofu commands via GitHub PR comments.
+- [tf-via-pr-comments](https://github.com/devsectop/tf-via-pr-comments) - GitHub Action to run Terraform or OpenTofu CLI commands via PR comments.
 - [terraform-github-actions](https://github.com/dflook/terraform-github-actions) - GitHub Actions for OpenTofu.
 
 ### Tests


### PR DESCRIPTION
Hi @virtualroot (Alejandro), many thanks for including TF-Via-PR-Comments to this awesome list; I'm the project maintainer and I had no idea it was featured here after the [Slack announcement](https://opentofucommunity.slack.com/archives/C05RKQMCQBA/p1698661440897909?thread_ts=1697718860.962899&cid=C05RKQMCQBA)!

Today, we shipped the biggest update to-date and finally made it available on [GitHub Actions Marketplace](https://github.com/marketplace/actions/tf-via-pr-comments). This involved a name change to more accurately reflect its purpose, so this PR updates the link.

For quick reference, here's a preview of the GitHub Action... in action.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/devsectop/tf-via-pr-comments/main/assets/screenshot_dark.png">
  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/devsectop/tf-via-pr-comments/main/assets/screenshot_light.png">
  <img
    alt="Screenshot of the author's TF command in a PR comment followed by github-action bot's TF output response in the next comment."
    src="https://raw.githubusercontent.com/devsectop/tf-via-pr-comments/main/assets/screenshot_dark.png">
</picture>
