### PR TITLE
Updating encryption link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ## Features
 
-- [End-to-end encryption for state files](https://twitter.com/OpenTofuOrg/status/1696597790661677207) 🚧
+- [End-to-end encryption for state files](https://youtu.be/rR4IbhlRSkI) 🚧
 - [OCI-compliant registry support](https://twitter.com/OpenTofuOrg/status/1696913055576387599) 🚧
 
 ## Tools


### PR DESCRIPTION
This change updates the encryption link to the latest video published by the OpenTofu team on the topic.