### PR TITLE
Disable double-link check

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
 
 ## Features
 
+<!--lint disable double-link-->
+
 - [1.8 - Override files for OpenTofu (.tofu)](https://opentofu.org/docs/intro/whats-new/#override-files-for-opentofu-keeping-compatibility)
 - [1.8 - Early variable and locals evaluation](https://opentofu.org/docs/intro/whats-new/#early-variablelocals-evaluation)
 - [1.7 - End-to-end encryption for state files](https://opentofu.org/docs/v1.7/intro/whats-new/#state-encryption)
@@ -50,6 +52,8 @@
 - [1.7 - Removed block](https://opentofu.org/docs/v1.7/intro/whats-new/#removed-block)
 - [1.7 - Loopable import blocks](https://opentofu.org/docs/v1.7/intro/whats-new/#loopable-import-blocks)
 - [OCI-compliant registry support](https://twitter.com/OpenTofuOrg/status/1696913055576387599) 🚧
+
+<!--lint enable double-link-->
 
 ## Tools
 


### PR DESCRIPTION
```
  README.md:46:3
  ✖  46:3  https://opentofu.org/docs/intro/whats-new/#override-files-for-opentofu-keeping-compatibility  remark-lint:double-link
  ✖  47:3  https://opentofu.org/docs/intro/whats-new/#early-variablelocals-evaluation                    remark-lint:double-link
  ✖  48:3  https://opentofu.org/docs/v1.7/intro/whats-new/#state-encryption                              remark-lint:double-link
  ✖  49:3  https://opentofu.org/docs/v1.7/intro/whats-new/#provider-defined-functions                    remark-lint:double-link
  ✖  50:3  https://opentofu.org/docs/v1.7/intro/whats-new/#removed-block                                 remark-lint:double-link
  ✖  51:3  https://opentofu.org/docs/v1.7/intro/whats-new/#loopable-import-blocks                        remark-lint:double-link

  6 errors
```