### PR TITLE
Add Terraform Academy OpenTofu Practitioner Path to Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - [Fork announcement](https://opentofu.org/announcement)
 - [Registry](https://github.com/opentofu/registry)
 - [Registry MCP Server](https://github.com/opentofu/opentofu-mcp-server#opentofu-mcp-server)
-- [Weekly updates](https://github.com/opentofu/opentofu/blob/main/WEEKLY_UPDATES.md)
+- [Weekly updates](https://github.com/opentofu/opentofu/discussions/categories/weekly-updates)
 - [Office hours](https://www.youtube.com/watch?v=aEoMzUza6Ok&list=PLnVotLM2QsyhCc1_8PA7fbVF-ixt4_XAY)
 - [Technical Steering Committee updates](https://github.com/opentofu/org/tree/main/TSC)
 
@@ -46,11 +46,11 @@
 
 <!--lint disable double-link-->
 
-- [1.10 - Enhanced moved and removed blocks](https://opentofu.org/docs/intro/whats-new/#enhanced-moved-and-removed-blocks)
-- [1.10 - External key providers](https://opentofu.org/docs/intro/whats-new/#external-key-providers)
+- [1.10 - Enhanced moved and removed blocks](https://opentofu.org/docs/v1.10/intro/whats-new/#enhanced-moved-and-removed-blocks)
+- [1.10 - External key providers](https://opentofu.org/docs/v1.10/intro/whats-new/#external-key-providers)
 - [1.10 - OCI registry support](https://opentofu.org/docs/cli/oci_registries/)
-- [1.10 - S3 native state locking](https://opentofu.org/docs/intro/whats-new/#native-s3-state-locking)
-- [1.10 - Target and exclude files](https://opentofu.org/docs/intro/whats-new/#target-and-exclude-files)
+- [1.10 - S3 native state locking](https://opentofu.org/docs/v1.10/intro/whats-new/#native-s3-state-locking)
+- [1.10 - Target and exclude files](https://opentofu.org/docs/v1.10/intro/whats-new/#target-and-exclude-files)
 - [1.9 - Provider iteration with for_each](https://opentofu.org/docs/v1.9/intro/whats-new/#provider-iteration-for_each)
 - [1.9 - The -exclude flag](https://opentofu.org/docs/v1.9/intro/whats-new/#the--exclude-flag)
 - [1.8 - Early variable and locals evaluation](https://opentofu.org/docs/v1.8/intro/whats-new/#early-variablelocals-evaluation)

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
 - [Terraform in Depth](https://www.manning.com/books/terraform-in-depth) - Book with OpenTofu sections.
 - [Infrastructure automation with OpenTofu](https://www.udemy.com/course/infrastructure-automation-with-opentofu-hands-on-devops/?couponCode=1D97F4D8FFE62E296BE1) - Learn infrastructure provisioning with lectures, quizzes, hands-on demos and coding exercises.
 - [Migrating From Terraform To OpenTofu](https://www.youtube.com/watch?v=v9rJgtHzxUk) - Introduction to OpenTofu history and how to migrate.
+- [Terraform Academy OpenTofu Practitioner Path](https://www.terraformacademy.app/max/labs/opentofu-basics.html) - Interactive browser based lab covering native state and plan encryption with PBKDF2 and AES-GCM, plus a full practitioner readiness path that reuses HCL fundamentals applicable to OpenTofu 1.6 and later.
 
 ## Media
 


### PR DESCRIPTION
Adds Terraform Academy under the Learning section.

Terraform Academy ships an interactive browser based lab and a practitioner readiness path that are OpenTofu specific:

- The lab walks the learner through OpenTofu's native state and plan encryption using a PBKDF2 key provider with AES-GCM, plus a small `random_pet` and `local_file` example so the full `tofu init`, `tofu plan`, `tofu apply` workflow runs end to end. State encryption is one of the headline differences between OpenTofu and Terraform, so the lab is built around that feature rather than copying a generic Terraform exercise.
- The cert path reuses HCL fundamentals modules. This is honest about the relationship: OpenTofu is configuration compatible with Terraform 1.5.x, so the language fundamentals carry over, and the OpenTofu specific content lives in the lab and in additional content on the roadmap.

Per CONTRIBUTING.md the link is a learning resource that targets OpenTofu directly. There is no paid wall on the lab page itself, and OpenTofu specific content will continue to grow on the platform.

URL: https://www.terraformacademy.app/max/labs/opentofu-basics.html

Format follows the existing convention in the Learning section: dash separator, single sentence description, period terminated.